### PR TITLE
Include coordinates mixin in PlaidPlot component.

### DIFF
--- a/addon/components/plaid-axis/component.js
+++ b/addon/components/plaid-axis/component.js
@@ -34,7 +34,7 @@ export default Ember.Component.extend(GroupElement, {
 
   xOffset: 0,
 
-  yOffset: 8,
+  yOffset: 0,
 
   didInsertElement() {
     this._super();

--- a/addon/components/plaid-plot.js
+++ b/addon/components/plaid-plot.js
@@ -1,7 +1,8 @@
 import Ember from 'ember';
 import layout from '../templates/components/plaid-plot';
+import Coordinates from '../mixins/coordinates';
 
-const PlotComponent = Ember.Component.extend({
+const PlotComponent = Ember.Component.extend(Coordinates, {
   layout,
 
   tagName: 'svg',
@@ -24,7 +25,7 @@ const PlotComponent = Ember.Component.extend({
    * @public
    * @type {D3 Scale}
    */
-  yScale: null,
+  yScale: null
 
   /**
    * Represents the coordinates to render the main graphic.
@@ -36,7 +37,7 @@ const PlotComponent = Ember.Component.extend({
    * @public
    * @type {Object}
    */
-  plotArea: {}
+  //  plotArea: {}
 
 });
 

--- a/addon/helpers/area.js
+++ b/addon/helpers/area.js
@@ -12,7 +12,13 @@ export function area([width, height], hash) {
     height: height - margin.top - margin.bottom,
     width: width - margin.left - margin.right,
     outerWidth: width,
-    outerHeight: height
+    outerHeight: height,
+    margin: {
+      top: margin.top,
+      left: margin.left,
+      bottom: margin.bottom,
+      right: margin.right
+    }
   };
 }
 

--- a/addon/mixins/plot-area.js
+++ b/addon/mixins/plot-area.js
@@ -39,7 +39,13 @@ export default Ember.Mixin.create({
         height: height - margin.top - margin.bottom,
         width: width - margin.left - margin.right,
         outerWidth: width,
-        outerHeight: height
+        outerHeight: height,
+        margin: {
+          top: margin.top,
+          left: margin.left,
+          bottom: margin.bottom,
+          right: margin.right
+        }
       };
     }
   })

--- a/tests/unit/helpers/area-test.js
+++ b/tests/unit/helpers/area-test.js
@@ -13,6 +13,7 @@ test('it returns an area hash', function(assert) {
     'outerWidth': 640,
     'right': 624,
     'top': 24,
-    'width': 608
+    'width': 608,
+    'margin': { 'top': 24, 'left': 16, 'bottom': 24, 'right': 16 }
   }, 'contains correct area attributes');
 });


### PR DESCRIPTION
This allows us to set sensible defaults for the PlaidPlot component,
that can be overwritten with either a user-supplied plotArea object, or
via the area helper.

Also, removes the yOffset of 8 from the yOffset, as it is a default that
leads to confusion.

Something we found in the changes meant for this PR, is the complexity
in trying to automatically set axis x and y positions. The fundamental
problem with it, is that when creating the visualization, maximum-plaid
doesn't know of the graph's orientation. In the process, it doesn't know
whether to prioritize the top or bottom margins for setting the starting
draw position of the axes(and the graph itself). We should think about
adding an 'orientation' system to the entire plaid-plot
component. [Issue](https://github.com/ivanvanderbyl/maximum-plaid/issues/14)

Thanks for help in developing this to @audsull.
