### PR TITLE
updated pairBy can listen to array object changes 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,22 +13,8 @@ insert_final_newline = true
 indent_style = space
 indent_size = 2
 
-[*.js]
-indent_style = space
-indent_size = 2
-
 [*.hbs]
 insert_final_newline = false
-indent_style = space
-indent_size = 2
-
-[*.css]
-indent_style = space
-indent_size = 2
-
-[*.html]
-indent_style = space
-indent_size = 2
 
 [*.{diff,md}]
 trim_trailing_whitespace = false

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,17 @@
+module.exports = {
+  root: true,
+  parserOptions: {
+    ecmaVersion: 7,
+    sourceType: 'module'
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:ember-suave/recommended'
+  ],
+  env: {
+    'browser': true,
+    'es6': true
+  },
+  rules: {
+  }
+};

--- a/.jshintrc
+++ b/.jshintrc
@@ -27,6 +27,6 @@
   "strict": false,
   "white": false,
   "eqnull": true,
-  "esnext": true,
+  "esversion": 6,
   "unused": true
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,13 @@ sudo: false
 
 cache:
   directories:
-    - node_modules
+    - $HOME/.npm
+    - $HOME/.cache # includes bowers cache
 
 env:
-  - EMBER_TRY_SCENARIO=default
-  - EMBER_TRY_SCENARIO=ember-2.4
+  # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
+  - EMBER_TRY_SCENARIO=ember-lts-2.4
+  - EMBER_TRY_SCENARIO=ember-lts-2.8
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
@@ -22,14 +24,17 @@ matrix:
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
-  - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
-  - "npm config set spin false"
-  - "npm install -g npm@^2"
+  - npm config set spin false
+  - npm install -g bower
+  - bower --version
+  - npm install phantomjs-prebuilt
+  - node_modules/phantomjs-prebuilt/bin/phantomjs --version
 
 install:
-  - npm install -g bower
   - npm install
   - bower install
 
 script:
-  - ember try $EMBER_TRY_SCENARIO test --skip-cleanup
+  # Usually, it's ok to finish the test scenario without reverting
+  #  to the addon's original dependency state, skipping "cleanup".
+  - ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # maximum plaid changelog
 
+### HEAD (Dec 06, 2016)
+
+- Updated to Ember 2.10
+
 ### 0.1.2 (May 30, 2016)
 
 - Version bumped because of NPM conflict.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**Deprecated: Please see (and use) [ember-primer](https://github.com/ember-visualization/ember-primer) instead, as this is no longer maintained**
+
 ![Maximum Plaid](/logo/maximum-plaid-logo.png)
 
 [![Build Status](https://travis-ci.org/ivanvanderbyl/maximum-plaid.svg?branch=master)](https://travis-ci.org/ivanvanderbyl/maximum-plaid)

--- a/addon/components/plaid-axis/component.js
+++ b/addon/components/plaid-axis/component.js
@@ -43,7 +43,7 @@ export default Component.extend(GroupElement, {
 
   /**
    * The format used for the ticks for this axis.
-   * [See D3 docs for more details](https://github.com/d3/d3/wiki/SVG-Axes#tickFormat)
+   * [See D3 docs for more details](https://github.com/d3/d3-axis#axis_tickFormat)
    *
    * @public
    * @type {Function}
@@ -52,7 +52,7 @@ export default Component.extend(GroupElement, {
 
   /**
    * The inner tick size for the ticks for this axis.
-   * [See D3 docs for more details](https://github.com/d3/d3/wiki/SVG-Axes#innerTickSize)
+   * [See D3 docs for more details](https://github.com/d3/d3-axis#axis_tickSizeInner)
    *
    * @public
    * @type {Number}
@@ -61,12 +61,21 @@ export default Component.extend(GroupElement, {
 
   /**
    * The outer tick size for the ticks for this axis.
-   * [See D3 docs for more details](https://github.com/d3/d3/wiki/SVG-Axes#outerTickSize)
+   * [See D3 docs for more details](https://github.com/d3/d3-axis#axis_tickSizeOuter)
    *
    * @public
    * @type {Number}
    */
   tickSizeOuter: 8,
+
+  /**
+   * Explicit tick values for this axis.
+   * [See D3 docs for more details](https://github.com/d3/d3-axis#axis_tickValues)
+   *
+   * @public
+   * @type {Array}
+   */
+  tickValues: null,
 
   xOffset: 0,
 
@@ -77,13 +86,14 @@ export default Component.extend(GroupElement, {
   },
 
   drawAxis() {
-    let { y, x, xOffset, yOffset, scale, orientation, tickFormat, ticks, tickSizeInner, tickSizeOuter } =
-      this.getProperties('y', 'x', 'xOffset', 'yOffset', 'scale', 'orientation', 'tickFormat', 'ticks', 'tickSizeInner', 'tickSizeOuter');
+    let { y, x, xOffset, yOffset, scale, orientation, tickFormat, ticks, tickSizeInner, tickSizeOuter, tickValues } =
+      this.getProperties('y', 'x', 'xOffset', 'yOffset', 'scale', 'orientation', 'tickFormat', 'ticks', 'tickSizeInner', 'tickSizeOuter', 'tickValues');
 
     let axis = this.createAxis(orientation, scale);
 
     axis.tickFormat(tickFormat);
     axis.tickSize(tickSizeInner, tickSizeOuter);
+    axis.tickValues(tickValues);
     axis.scale(scale);
 
     if (ticks) {

--- a/addon/components/plaid-plot.js
+++ b/addon/components/plaid-plot.js
@@ -1,8 +1,8 @@
-import Ember from 'ember';
 import layout from '../templates/components/plaid-plot';
-import Coordinates from '../mixins/coordinates';
+import Coordinates from 'maximum-plaid/mixins/coordinates';
+import Component from 'ember-component';
 
-const PlotComponent = Ember.Component.extend(Coordinates, {
+let PlotComponent = Component.extend(Coordinates, {
   layout,
 
   tagName: 'svg',

--- a/addon/components/plaid-symbol.js
+++ b/addon/components/plaid-symbol.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import Component from 'ember-component';
 
 import {
   symbol,
@@ -27,7 +28,7 @@ const {
  *   {{plaid-symbol "TYPE" x y}}
  */
 
-const SymbolComponent = Ember.Component.extend({
+const SymbolComponent = Component.extend({
   tagName: 'path',
   attributeBindings: [
     'symbolData:d',

--- a/addon/helpers/area.js
+++ b/addon/helpers/area.js
@@ -1,7 +1,10 @@
 import Ember from 'ember';
 import box from '../utils/box-expression';
+const { Helper } = Ember;
 
-export function area([width, height], hash) {
+export function area(params, hash) {
+  let [width, height] = params.slice();
+  hash = Object.assign({}, hash);
   let margin = hash.margin ? box(hash.margin) : { top: 0, right: 0, bottom: 0, left: 0 };
 
   return {
@@ -22,4 +25,4 @@ export function area([width, height], hash) {
   };
 }
 
-export default Ember.Helper.helper(area);
+export default Helper.helper(area);

--- a/addon/helpers/curve.js
+++ b/addon/helpers/curve.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-const { isPresent, assert, String: { camelize } } = Ember;
+const { Helper, isPresent, assert, String: { camelize } } = Ember;
 
 import {
   curveBasisClosed,
@@ -58,4 +58,4 @@ export function curve([curveName], hash) {
   return curveFn;
 }
 
-export default Ember.Helper.helper(curve);
+export default Helper.helper(curve);

--- a/addon/helpers/extent.js
+++ b/addon/helpers/extent.js
@@ -1,10 +1,10 @@
 import Ember from 'ember';
 import { extent as arrayExtent, max } from 'd3-array';
-const { get } = Ember;
+const { Helper, get, isPresent } = Ember;
 
 export function extent([array, accessor], options) {
 
-  if (!!accessor) {
+  if (isPresent(accessor)) {
     array = array.map((d) => get(d, accessor));
   }
 
@@ -15,4 +15,4 @@ export function extent([array, accessor], options) {
   }
 }
 
-export default Ember.Helper.helper(extent);
+export default Helper.helper(extent);

--- a/addon/helpers/format-fn.js
+++ b/addon/helpers/format-fn.js
@@ -1,14 +1,14 @@
 import Ember from 'ember';
 import { format } from './format';
 
+const { Helper } = Ember;
+
 export function formatFn(params, hash) {
   return function formatFnHelper(value) {
-    if (!hash) {
-      hash = {};
-    }
+    hash = Object.assign({}, hash);
     hash.format = params[0];
     return format([value], hash);
   };
 }
 
-export default Ember.Helper.helper(formatFn);
+export default Helper.helper(formatFn);

--- a/addon/helpers/format.js
+++ b/addon/helpers/format.js
@@ -1,10 +1,9 @@
 import Ember from 'ember';
-import {format as d3Format} from 'd3-format';
+import { format as d3Format } from 'd3-format';
+const { Helper } = Ember;
 
 export function format([value], hash) {
-  if (!hash) {
-    hash = {};
-  }
+  hash = Object.assign({}, hash);
 
   let result;
   if (!hash.format) {
@@ -28,4 +27,4 @@ export function format([value], hash) {
   return result;
 }
 
-export default Ember.Helper.helper(format);
+export default Helper.helper(format);

--- a/addon/helpers/linear-scale.js
+++ b/addon/helpers/linear-scale.js
@@ -1,7 +1,12 @@
 import Ember from 'ember';
 import { scaleLinear } from 'd3-scale';
+const { Helper } = Ember;
 
-export function linearScale([domain, range], hash = {}) {
+export function linearScale(params, hash = {}) {
+  params = params.slice();
+  let [domain, range] = params;
+  hash = Object.assign({}, hash);
+
   let scale = scaleLinear().domain(domain);
   if (hash && hash.round) {
     scale.rangeRound(range);
@@ -12,4 +17,4 @@ export function linearScale([domain, range], hash = {}) {
   return scale;
 }
 
-export default Ember.Helper.helper(linearScale);
+export default Helper.helper(linearScale);

--- a/addon/helpers/pair-by.js
+++ b/addon/helpers/pair-by.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-const { assert } = Ember;
+const { Helper, isArray, assert } = Ember;
 
 /**
  * @pairBy(params);
@@ -16,10 +16,11 @@ const { assert } = Ember;
  * @public
  * @return {Array[Array[2]]}
  */
-export function pairBy(params) {
+export function pairBy(args = []) {
+  let params = args.slice();
   assert('pair-by requires at least 2 arguments: key, data', params.length >= 2);
   let data = params.pop();
-  assert('last argument must be an array of objects', Ember.isArray(data));
+  assert('last argument must be an array of objects', isArray(data));
 
   let [...keys] = params;
 
@@ -31,4 +32,4 @@ export function pairBy(params) {
   });
 }
 
-export default Ember.Helper.helper(pairBy);
+export default Helper.helper(pairBy);

--- a/addon/mixins/coordinates.js
+++ b/addon/mixins/coordinates.js
@@ -2,5 +2,7 @@ import Ember from 'ember';
 import Dimensions from './dimensions';
 import PlotArea from './plot-area';
 
-export default Ember.Mixin.create(Dimensions, PlotArea, {
+const { Mixin } = Ember;
+
+export default Mixin.create(Dimensions, PlotArea, {
 });

--- a/addon/mixins/dimensions.js
+++ b/addon/mixins/dimensions.js
@@ -2,6 +2,8 @@ import Ember from 'ember';
 import GlobalResize from 'maximum-plaid/mixins/global-resize';
 
 const {
+  Mixin,
+  K,
   run: {
     throttle,
     next
@@ -9,7 +11,7 @@ const {
   on
 } = Ember;
 
-export default Ember.Mixin.create(GlobalResize, {
+export default Mixin.create(GlobalResize, {
 
   width: 1,
   height: 1,
@@ -18,7 +20,7 @@ export default Ember.Mixin.create(GlobalResize, {
     next(this, this.measureDimensions);
   }),
 
-  didMeasureDimensions: Ember.K,
+  didMeasureDimensions: K,
 
   didResize() {
     // window.requestAnimationFrame(this.measureDimensions.bind(this));
@@ -31,12 +33,14 @@ export default Ember.Mixin.create(GlobalResize, {
     }
 
     let rect = this.element.getBoundingClientRect();
-    this.setProperties({
-      width: rect.width,
-      height: rect.height
-    });
+    next(this, function() {
+      this.setProperties({
+        width: rect.width,
+        height: rect.height
+      });
 
-    this.trigger('didMeasureDimensions');
+      this.trigger('didMeasureDimensions');
+    });
   }
 
 });

--- a/addon/mixins/global-resize.js
+++ b/addon/mixins/global-resize.js
@@ -1,15 +1,17 @@
 import Ember from 'ember';
 
-export default Ember.Mixin.create({
-  _setupResizeListener: Ember.on('didInsertElement', function() {
-    Ember.$(window).on(`resize.${this.elementId}`, (event) => {
-      this.didResize(event);
+const { Mixin, on, $, K, run } = Ember;
+
+export default Mixin.create({
+  _setupResizeListener: on('didInsertElement', function() {
+    $(window).on(`resize.${this.elementId}`, (event) => {
+      run.next(this, this.didResize, event);
     });
   }),
 
-  _teardownResizeListener: Ember.on('willDestroyElement', function() {
-    Ember.$(window).off(`resize.${this.elementId}`);
+  _teardownResizeListener: on('willDestroyElement', function() {
+    $(window).off(`resize.${this.elementId}`);
   }),
 
-  didResize: Ember.K
+  didResize: K
 });

--- a/addon/mixins/group-element.js
+++ b/addon/mixins/group-element.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import { select } from 'd3-selection';
 
-const { computed } = Ember;
+const { computed, Mixin } = Ember;
 
 /**
  * @public
@@ -9,7 +9,7 @@ const { computed } = Ember;
  * variable of `this.selection` to a D3 selection of itself.
  */
 
-export default Ember.Mixin.create({
+export default Mixin.create({
   tagName: 'g',
 
   x: 0,

--- a/addon/mixins/plot-area.js
+++ b/addon/mixins/plot-area.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
 import box from '../utils/box-expression';
 
-const { computed } = Ember;
+const { computed, Mixin } = Ember;
 
-export default Ember.Mixin.create({
+export default Mixin.create({
 
   /**
    * Specifies them margin for the main graph, such that you can position

--- a/addon/utils/box-expression.js
+++ b/addon/utils/box-expression.js
@@ -1,17 +1,18 @@
 import Ember from 'ember';
+const { assert } = Ember;
 
 export default function box(expr) {
   if (typeof expr !== 'object') {
     expr = String(expr).split(/\s+/).map(Number);
   } else {
-    return [ 'left', 'right', 'top', 'bottom' ].reduce((accum, dir) => {
+    return ['left', 'right', 'top', 'bottom'].reduce((accum, dir) => {
       accum[dir] = Number(expr[dir]) || 0;
 
       return accum;
     }, {});
   }
 
-  Ember.assert('Box expr must be have 1-4 numbers', !expr.filter(isNaN).length);
+  assert('Box expr must be have 1-4 numbers', !expr.filter(isNaN).length);
 
   switch (expr.length) {
     // 1 value = all four sides

--- a/bower.json
+++ b/bower.json
@@ -1,11 +1,7 @@
 {
-  "name": "plaid",
+  "name": "maximum-plaid",
   "dependencies": {
-    "ember": "~2.6.0-beta.3",
-    "ember-cli-shims": "~0.1.1",
-    "ember-cli-test-loader": "0.2.2",
-    "ember-qunit-notifications": "0.1.0",
-    "bourbon": "4.2.6",
-    "firebase": "^2.1.0"
+    "ember": "~2.10.0",
+    "ember-cli-shims": "0.1.3"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,8 @@
   "name": "maximum-plaid",
   "dependencies": {
     "ember": "~2.10.0",
-    "ember-cli-shims": "0.1.3"
+    "ember-cli-shims": "0.1.3",
+    "bourbon": "4.2.6",
+    "firebase": "^2.1.0"
   }
 }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,19 +2,24 @@
 module.exports = {
   scenarios: [
     {
-      name: 'default',
+      name: 'ember-lts-2.4',
       bower: {
-        dependencies: { }
+        dependencies: {
+          'ember': 'components/ember#lts-2-4'
+        },
+        resolutions: {
+          'ember': 'lts-2-4'
+        }
       }
     },
     {
-      name: 'ember-2.4',
+      name: 'ember-lts-2.8',
       bower: {
         dependencies: {
-          'ember': '~2.4.0'
+          'ember': 'components/ember#lts-2-8'
         },
         resolutions: {
-          'ember': '~2.4.0'
+          'ember': 'lts-2-8'
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -6,44 +6,51 @@
     "doc": "doc",
     "test": "tests"
   },
+  "license": "MIT",
+  "author": "Ivan Vanderbyl",
+  "directories": {
+    "doc": "doc",
+    "test": "tests"
+  },
+  "repository": "ivanvanderbyl/plaid",
   "scripts": {
     "build": "ember build",
     "start": "ember server",
-    "test": "ember try:testall",
+    "test": "ember try:each",
     "deploy": "ember github-pages:commit --message \"Deploy gh-pages from commit $(git rev-parse HEAD)\"; git push; git checkout -"
   },
-  "repository": "ivanvanderbyl/plaid",
-  "engines": {
-    "node": ">= 4.0"
+  "dependencies": {
+    "ember-cli-babel": "^5.1.7",
+    "ember-math-helpers": "1.0.0",
+    "ember-d3-helpers": ">=0.5.2",
+    "ember-composable-helpers": "^0.26.2",
+    "ember-d3": "ivanvanderbyl/ember-d3",
+    "d3": "^4.4.0"
   },
-  "author": "Ivan Vanderbyl",
-  "license": "MIT",
   "devDependencies": {
-    "broccoli-asset-rev": "^2.4.2",
-    "ember-cli": "^2.8.0",
-    "ember-cli-app-version": "^1.0.0",
-    "ember-cli-bourbon": "1.2.2",
-    "ember-cli-dependency-checker": "^1.2.0",
-    "ember-cli-github-pages": "0.0.8",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.1",
-    "ember-cli-inject-live-reload": "^1.4.0",
-    "ember-cli-jshint": "^1.0.0",
-    "ember-cli-qunit": "^2.0.0",
-    "ember-cli-release": "1.0.0-beta.1",
-    "ember-cli-sass": "5.3.1",
+    "broccoli-asset-rev": "^2.4.5",
+    "ember-ajax": "^2.4.1",
+    "ember-cli": "2.10.0",
+    "ember-cli-app-version": "^2.0.0",
+    "ember-cli-dependency-checker": "^1.3.0",
+    "ember-cli-htmlbars": "^1.0.10",
+    "ember-cli-htmlbars-inline-precompile": "^0.3.3",
+    "ember-cli-inject-live-reload": "^1.4.1",
+    "ember-cli-jshint": "^2.0.1",
+    "ember-cli-qunit": "^3.0.1",
+    "ember-cli-release": "^0.2.9",
     "ember-cli-sri": "^2.1.0",
+    "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "2.5.3",
+    "ember-data": "^2.10.0",
     "ember-disable-prototype-extensions": "^1.1.0",
-    "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
-    "ember-suave": "2.0.1",
-    "ember-sublime": "0.0.4",
-    "ember-try": "^0.2.2",
     "emberfire": "1.6.6",
-    "loader.js": "^4.0.4"
+    "ember-cli-eslint": "3.0.0",
+    "eslint-plugin-ember-suave": "^1.0.0",
+    "loader.js": "^4.0.10"
   },
   "keywords": [
     "ember-addon",
@@ -54,13 +61,8 @@
     "charts",
     "charting-package"
   ],
-  "dependencies": {
-    "ember-cli-babel": "^5.1.6",
-    "ember-cli-htmlbars": "^1.0.5",
-    "ember-math-helpers": "1.0.0",
-    "ember-d3-helpers": ">=0.5.2",
-    "ember-composable-helpers": "^0.26.2",
-    "ember-d3": "ivanvanderbyl/ember-d3"
+  "engines": {
+    "node": ">= 4.6"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "ember-cli-jshint": "^1.0.0",
     "ember-cli-qunit": "^2.0.0",
     "ember-cli-release": "1.0.0-beta.1",
+    "ember-cli-sass": "5.3.1",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "2.5.3",
@@ -56,7 +57,6 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.5",
-    "ember-cli-sass": "5.3.1",
     "ember-math-helpers": "1.0.0",
     "ember-d3-helpers": ">=0.5.2",
     "ember-composable-helpers": "^0.26.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
-    "ember-cli": "2.5.0",
+    "ember-cli": "^2.8.0",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-bourbon": "1.2.2",
     "ember-cli-dependency-checker": "^1.2.0",
@@ -60,7 +60,7 @@
     "ember-math-helpers": "1.0.0",
     "ember-d3-helpers": ">=0.5.2",
     "ember-composable-helpers": "^0.26.2",
-    "ember-cli-d3-shape": ">=0.9.2-4.1.1.0"
+    "ember-d3": "ivanvanderbyl/ember-d3"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -32,8 +32,6 @@
     "ember-cli-release": "1.0.0-beta.1",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-composable-helpers": "0.26.0",
-    "ember-d3-scale": "0.1.5",
     "ember-data": "2.5.3",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-disable-proxy-controllers": "^1.0.1",
@@ -60,7 +58,9 @@
     "ember-cli-htmlbars": "^1.0.5",
     "ember-cli-sass": "5.3.1",
     "ember-math-helpers": "1.0.0",
-    "ember-cli-d3-shape": "^0.8.6"
+    "ember-d3-helpers": ">=0.5.2",
+    "ember-composable-helpers": "^0.26.2",
+    "ember-cli-d3-shape": ">=0.9.2-4.1.1.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -8,10 +8,6 @@
   },
   "license": "MIT",
   "author": "Ivan Vanderbyl",
-  "directories": {
-    "doc": "doc",
-    "test": "tests"
-  },
   "repository": "ivanvanderbyl/plaid",
   "scripts": {
     "build": "ember build",
@@ -23,7 +19,8 @@
     "ember-cli-babel": "^5.1.7",
     "ember-math-helpers": "1.0.0",
     "ember-d3-helpers": ">=0.5.2",
-    "ember-composable-helpers": "^0.26.2",
+    "ember-cli-htmlbars": "^1.0.10",
+    "ember-composable-helpers": "^1.1.2",
     "ember-d3": "ivanvanderbyl/ember-d3",
     "d3": "^4.4.0"
   },
@@ -32,13 +29,15 @@
     "ember-ajax": "^2.4.1",
     "ember-cli": "2.10.0",
     "ember-cli-app-version": "^2.0.0",
+    "ember-cli-bourbon": "1.2.2",
     "ember-cli-dependency-checker": "^1.3.0",
-    "ember-cli-htmlbars": "^1.0.10",
+    "ember-cli-eslint": "3.0.0",
     "ember-cli-htmlbars-inline-precompile": "^0.3.3",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-jshint": "^2.0.1",
     "ember-cli-qunit": "^3.0.1",
     "ember-cli-release": "^0.2.9",
+    "ember-cli-sass": "5.6.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
@@ -48,7 +47,6 @@
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "emberfire": "1.6.6",
-    "ember-cli-eslint": "3.0.0",
     "eslint-plugin-ember-suave": "^1.0.0",
     "loader.js": "^4.0.10"
   },

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  env: {
+    'embertest': true
+  }
+};

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -47,6 +47,6 @@
   "strict": false,
   "white": false,
   "eqnull": true,
-  "esnext": true,
+  "esversion": 6,
   "unused": true
 }

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -1,5 +1,6 @@
-import Ember from 'ember';
-export default Ember.Controller.extend({
+import Controller from 'ember-controller';
+
+export default Controller.extend({
 
   responseTimeMean: [],
 

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -3,22 +3,22 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Maximum Plaid</title>
-    <meta name="description" content="Template driven data visualisation for ambitious applications">
+    <title>Dummy</title>
+    <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     {{content-for "head"}}
 
-    <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/dummy.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
 
     {{content-for "head-footer"}}
   </head>
   <body>
     {{content-for "body"}}
 
-    <script src="assets/vendor.js"></script>
-    <script src="assets/dummy.js"></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/dummy.js"></script>
 
     {{content-for "body-footer"}}
   </body>

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -2,7 +2,8 @@ import Ember from 'ember';
 import config from './config/environment';
 
 const Router = Ember.Router.extend({
-  location: config.locationType
+  location: config.locationType,
+  rootURL: config.rootURL
 });
 
 Router.map(function() {

--- a/tests/dummy/app/routes/index.js
+++ b/tests/dummy/app/routes/index.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import Route from 'ember-route';
 
 const {
   inject,
@@ -6,7 +7,7 @@ const {
   String: { camelize }
 } = Ember;
 
-export default Ember.Route.extend({
+export default Route.extend({
   firebase: inject.service(),
 
   model() {
@@ -16,7 +17,7 @@ export default Ember.Route.extend({
       ref.once('value', function(snapshot) {
         let value = snapshot.val();
         let data = {};
-        Object.keys(value).map((key) => {
+        Object.keys(value).forEach((key) => {
           data[camelize(key)] = value[key];
         });
 

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -4,7 +4,7 @@ module.exports = function(environment) {
   var ENV = {
     modulePrefix: 'dummy',
     environment: environment,
-    baseURL: '/',
+    rootURL: '/',
     locationType: 'auto',
     EmberENV: {
       FEATURES: {
@@ -31,7 +31,7 @@ module.exports = function(environment) {
 
   if (environment === 'test') {
     // Testem prefers this...
-    ENV.baseURL = '/';
+    ENV.rootURL = '/';
     ENV.locationType = 'none';
 
     // keep test console output quieter
@@ -43,7 +43,7 @@ module.exports = function(environment) {
 
   if (environment === 'production') {
     ENV.locationType = 'hash';
-    ENV.baseURL = '/maximum-plaid/';
+    ENV.rootURL = '/maximum-plaid/';
 
   }
 

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -1,6 +1,9 @@
 import { module } from 'qunit';
+import Ember from 'ember';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
+
+const { RSVP: { Promise } } = Ember;
 
 export default function(name, options = {}) {
   module(name, {
@@ -8,16 +11,13 @@ export default function(name, options = {}) {
       this.application = startApp();
 
       if (options.beforeEach) {
-        options.beforeEach(...arguments);
+        return options.beforeEach.apply(this, arguments);
       }
     },
 
     afterEach() {
-      if (options.afterEach) {
-        options.afterEach(...arguments);
-      }
-
-      destroyApp(this.application);
+      let afterEach = options.afterEach && options.afterEach.apply(this, arguments);
+      return Promise.resolve(afterEach).then(() => destroyApp(this.application));
     }
   });
 }

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -5,8 +5,8 @@ import config from '../../config/environment';
 export default function startApp(attrs) {
   let application;
 
-  let attributes = Ember.merge({}, config.APP);
-  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
+  // use defaults, but you can override
+  let attributes = Ember.assign({}, config.APP, attrs);
 
   Ember.run(() => {
     application = Application.create(attributes);

--- a/tests/index.html
+++ b/tests/index.html
@@ -10,9 +10,9 @@
     {{content-for "head"}}
     {{content-for "test-head"}}
 
-    <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/dummy.css">
-    <link rel="stylesheet" href="assets/test-support.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
 
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
@@ -21,12 +21,11 @@
     {{content-for "body"}}
     {{content-for "test-body"}}
 
-    <script src="testem.js" integrity=""></script>
-    <script src="assets/vendor.js"></script>
-    <script src="assets/test-support.js"></script>
-    <script src="assets/dummy.js"></script>
-    <script src="assets/tests.js"></script>
-    <script src="assets/test-loader.js"></script>
+    <script src="/testem.js" integrity=""></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/test-support.js"></script>
+    <script src="{{rootURL}}assets/dummy.js"></script>
+    <script src="{{rootURL}}assets/tests.js"></script>
 
     {{content-for "body-footer"}}
     {{content-for "test-body-footer"}}


### PR DESCRIPTION
This PR is related to issue #38
An observer added to the pair-by.js helper allows for dynamic chart updating. 
addon/helpers/pair-by.js

```
import Ember from 'ember';
import Helper from 'ember-helper';
import observer from 'ember-metal/observer';
const { assert } = Ember;

export default Helper.extend({
    compute(params) {
        assert('pair-by requires at least 2 arguments: key, data', params.length >= 2);
        let data = params.pop();
        this.set('array', data);
        assert('last argument must be an array of objects', Ember.isArray(data));
        let [...keys] = params; 

        return data.map((d) => {
            return keys.reduce((acc, k, index) => {
                acc[index] = d[k];
                return acc;
            }, []);
        });
    },
    contentDidChange: observer('array.[]', function() {
        this.recompute();
    })
});
```
